### PR TITLE
Fix: EmailField에 validator 전달하지 않도록 변경

### DIFF
--- a/strawberry_be/api/serializers/signin_serializer.py
+++ b/strawberry_be/api/serializers/signin_serializer.py
@@ -1,7 +1,6 @@
 from django.contrib.auth import get_user_model
 
 # 이메일 유효성 검사 함수
-from django.core.validators import EmailValidator
 
 from rest_framework import serializers
 
@@ -16,9 +15,7 @@ User = get_user_model()
 
 class SigninSerializer(serializers.Serializer):
 
-    email = serializers.EmailField(
-        write_only=True, required=True, validators=[EmailValidator()]
-    )
+    email = serializers.EmailField(write_only=True, required=True)
     password = serializers.CharField(write_only=True, required=True)
     access_token = serializers.CharField(read_only=True)
 

--- a/strawberry_be/api/serializers/user_serializer.py
+++ b/strawberry_be/api/serializers/user_serializer.py
@@ -4,8 +4,6 @@ from django.contrib.auth import get_user_model
 # 비밀번호 유효성 검사 함수
 from django.contrib.auth.password_validation import validate_password
 
-from django.core.validators import EmailValidator
-
 from rest_framework import serializers
 
 from .error import USER_SERIALIZE_ERRORS
@@ -27,7 +25,7 @@ class UserSerializer(serializers.ModelSerializer):
             "user_type": {"write_only": True, "required": True},
         }
 
-    email = serializers.EmailField(required=True, validators=[EmailValidator()])
+    email = serializers.EmailField(required=True)
     # write_only: 데이터 입력 시에만 사용, 직렬화 출력에서 제외, 비밀번호 입력 시 사용, 응답에는 포함되지 않으므로 쉽게 노출 제어 가능
     password = serializers.CharField(
         write_only=True, required=True, validators=[validate_password]


### PR DESCRIPTION
### 📃 관련 이슈
<!-- 관련된 이슈 번호를 #숫자 형식으로 기재해주세요. 예: #42 -->
Closes: #5 

### 🐞 버그 설명
<!-- 발생한 버그에 대해 설명해주세요. -->
올바르지 못한 이메일 형식으로 로그인 요청 시,
invalid에 대한 에러 메세지가 두개가 첨부됨

![image](https://github.com/user-attachments/assets/d74b1278-513b-4935-a468-f7a1abf56847)

### 💻 재현 과정
<!-- 버그를 재현하는 과정을 단계별로 기재해주세요. -->
1. 올바르지 못한 이메일 형식 전달 (ex. adfqeradf)
2. 로그인 요청
3. 응답 확인


### ✅ 수정 내용
<!-- 버그 수정을 위해 작업한 내용을 간단히 요약해주세요. -->
<!--
  - 수정 사항 1
  - 수정 사항 2
  - ...
-->
#### EmailField에 validator 전달하지 않도록 변경
- EmailField는 자체적으로 초기화 시 EmailValidator를 수행함
```python
class EmailField(CharField):
    default_error_messages = {
        'invalid': _('Enter a valid email address.')
    }

    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        validator = EmailValidator(message=self.error_messages['invalid'])
        self.validators.append(validator)
```
- 따라서 중복 수행 삭제
```python
email = serializers.EmailField(write_only=True, required=True)
```
### ⚠️ 주의 사항
<!-- 버그 수정 시 유의해야 할 사항이 있다면 기재해주세요. -->
<!-- 없으면 '없음'이라고 기재해주세요. -->

### 🧪 테스트 과정
<!-- 수행한 테스트 케이스를 체크박스 형식으로 기재해주세요. -->

### 📖 참고 자료
<!-- 버그 수정 시 참고한 자료가 있다면 링크를 첨부해주세요. -->
<!-- 없으면 '없음'이라고 기재해주세요. -->

### ✔️ 체크리스트
<!-- 아래 체크리스트를 확인하고 해당하는 항목에 체크해주세요. -->
- [x] 버그가 적절히 수정되었는가?


### 🙏 기타 의견
<!-- 버그 수정과 관련하여 추가로 언급할 사항이 있다면 기재해주세요. -->
